### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/Velocity/build/build.properties
+++ b/Velocity/build/build.properties
@@ -121,7 +121,7 @@ repo.m2.url=http://www.ibiblio.org/maven2
 # Jars to be downloaded
 jar.antlr.version= 2.7.5
 jar.avalon-logkit.version= 2.1
-jar.commons-collections.version= 3.2.1
+jar.commons-collections.version= 3.2.2
 jar.commons-lang.version= 2.4
 jar.commons-logging.version= 1.1
 jar.jdom.version= 1.0

--- a/Velocity/pom.xml
+++ b/Velocity/pom.xml
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.1</version>
+      <version>3.2.2</version>
     </dependency>
     <dependency>
       <groupId>commons-lang</groupId>

--- a/Velocity/whiteboard/henning/using_ivy/build.properties
+++ b/Velocity/whiteboard/henning/using_ivy/build.properties
@@ -94,7 +94,7 @@ proxy.port= 80
 #
 # Jars to be included in the velocity-dep jar
 jar.avalon-logkit.version= 2.1
-jar.commons-collections.version= 3.1
+jar.commons-collections.version= 3.2.2
 jar.commons-lang.version= 2.1
 jar.oro.version= 2.0.8
 

--- a/Velocity/whiteboard/henning/using_ivy/ivy.xml
+++ b/Velocity/whiteboard/henning/using_ivy/ivy.xml
@@ -24,7 +24,7 @@
     <dependencies>
         <dependency name="antlr" rev="2.7.5" />
         <dependency name="avalon-logkit" rev="2.1" />
-        <dependency name="commons-collections" rev="3.1" />
+        <dependency name="commons-collections" rev="3.2.2" />
         <dependency name="commons-lang" rev="2.1" />
         <dependency name="jdom" rev="1.0" />
         <dependency name="junit" rev="3.8.1" />

--- a/Velocity/xdocs/docs/build.xml
+++ b/Velocity/xdocs/docs/build.xml
@@ -121,7 +121,7 @@ control the download with the <code>skip.jar.loading</code> and
   <td>No</td>  
 </tr>
 <tr>
-  <td><code>commons-collection-3.1.jar</code></td>
+  <td><code>commons-collection-3.2.2.jar</code></td>
   <td>Used in parsing configuration</td>
   <td>Yes</td>  
 </tr>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
